### PR TITLE
CMake: Make additional compiler flags configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(Haploflow)
-set(Boost_USE_STATIC_LIBS=ON)
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+if(NOT DEFINED Boost_USE_STATIC_LIBS)
+	set(Boost_USE_STATIC_LIBS=ON)
+endif
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -14,9 +16,11 @@ link_directories(
 	${Boost_LIBRARY_DIRS}
 )
 
-set(COMPILER_FLAGS
-	"-ggdb -Wall -L/usr/include -I/usr/include -std=c++0x -pipe -Wno-deprecated -pedantic"
-)
+if(NOT DEFINED COMPILER_FLAGS)
+	set(COMPILER_FLAGS
+		"-ggdb -Wall -L/usr/include -I/usr/include -std=c++0x -pipe -Wno-deprecated -pedantic"
+	)
+endif()
 
 add_executable(haploflow
 	main.cpp
@@ -30,8 +34,10 @@ add_executable(haploflow
 	UnitigGraph.cpp
 )
 
-set_target_properties(haploflow PROPERTIES
-	COMPILE_FLAGS ${COMPILER_FLAGS}
-)
+if(NOT "${COMPILER_FLAGS}" STREQUAL "")
+	set_target_properties(haploflow PROPERTIES
+		COMPILE_FLAGS ${COMPILER_FLAGS}
+	)
+endif()
 
 target_link_libraries(haploflow ${Boost_LIBRARIES})


### PR DESCRIPTION
Hi @AlphaSquad,

we are looking to add Haploflow to [Bioconda](https://bioconda.github.io/).
For our builds we use different compilation settings, e.g., we dynamically link to libraries (Boost) and also use custom compiler flags (to help with compatibility targets for our packages).

With these proposed changes the default settings for your own build are not changed but we'd have the possibility to diverge from the defaults when needed.

Cheers,
Marcel